### PR TITLE
Implement chirp search functionality

### DIFF
--- a/app/Http/Controllers/ChirpController.php
+++ b/app/Http/Controllers/ChirpController.php
@@ -10,14 +10,20 @@ class ChirpController extends Controller
 {
     use AuthorizesRequests;
 
-    public function index()
+    public function index(Request $request)
     {
+        $search = $request->input('search');
+
         $chirps = Chirp::with('user')
+            ->search($search)
             ->latest()
             ->take(50)  // Limit to 50 most recent chirps
             ->get();
 
-        return view('home', ['chirps' => $chirps]);
+        return view('home', [
+            'chirps' => $chirps,
+            'search' => $search ?? '',
+        ]);
     }
 
     public function store(Request $request)

--- a/app/Models/Chirp.php
+++ b/app/Models/Chirp.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Chirp extends Model
 {
+    use HasFactory;
     protected $fillable = [
         'message',
     ];
@@ -14,5 +17,14 @@ class Chirp extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function scopeSearch(Builder $query, ?string $search): Builder
+    {
+        if (empty($search)) {
+            return $query;
+        }
+
+        return $query->where('message', 'LIKE', '%'.$search.'%');
     }
 }

--- a/database/factories/ChirpFactory.php
+++ b/database/factories/ChirpFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Chirp>
+ */
+class ChirpFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'message' => fake()->sentence(),
+        ];
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -6,6 +6,33 @@
     <div class="max-w-2xl mx-auto">
         <h1 class="text-3xl font-bold mt-8">Latest Chirps</h1>
 
+        <!-- Search Form -->
+        <form method="GET" action="/" class="mt-8">
+            <div class="form-control">
+                <div class="join w-full">
+                    <input
+                        type="search"
+                        name="search"
+                        value="{{ $search }}"
+                        placeholder="Search chirps..."
+                        class="input input-bordered join-item flex-1"
+                        maxlength="255"
+                    >
+                    <button type="submit" class="btn btn-primary join-item">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                        Search
+                    </button>
+                    @if($search)
+                        <a href="/" class="btn btn-ghost join-item">
+                            Clear
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </form>
+
         <!-- Chirp Form -->
         <div class="card bg-base-100 shadow mt-8">
             <div class="card-body">
@@ -48,7 +75,13 @@
                             <svg class="mx-auto h-12 w-12 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
                             </svg>
-                            <p class="mt-4 text-base-content/60">No chirps yet. Be the first to chirp!</p>
+                            <p class="mt-4 text-base-content/60">
+                                @if($search)
+                                    No chirps found matching "{{ $search }}". Try a different search term.
+                                @else
+                                    No chirps yet. Be the first to chirp!
+                                @endif
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/tests/Browser/ChirpSearchBrowserTest.php
+++ b/tests/Browser/ChirpSearchBrowserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+test('can search for chirps using search form', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Laravel is awesome']);
+    Chirp::factory()->for($user)->create(['message' => 'PHP is great']);
+    Chirp::factory()->for($user)->create(['message' => 'Laravel testing']);
+
+    $page = visit('/');
+
+    $page->assertSee('Laravel is awesome')
+        ->assertSee('PHP is great')
+        ->assertSee('Laravel testing')
+        ->fill('search', 'Laravel')
+        ->click('Search')
+        ->assertSee('Laravel is awesome')
+        ->assertSee('Laravel testing')
+        ->assertDontSee('PHP is great');
+});
+
+test('clear button appears when search is active', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Test chirp']);
+
+    $page = visit('/');
+
+    $page->assertDontSee('Clear');
+
+    $page->fill('search', 'Test')
+        ->click('Search')
+        ->assertSee('Clear');
+});
+
+test('search input preserves value after search', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Searchable content']);
+
+    $page = visit('/');
+
+    $page->fill('search', 'Searchable')
+        ->click('Search')
+        ->assertInputValue('search', 'Searchable');
+});
+
+test('clear button redirects to home and clears search', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Test chirp']);
+
+    $page = visit('/?search=Test');
+
+    $page->assertSee('Clear')
+        ->click('Clear')
+        ->assertInputValue('search', '');
+});
+
+test('displays no results message when search returns nothing', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Existing chirp']);
+
+    $page = visit('/');
+
+    $page->fill('search', 'NonexistentKeyword')
+        ->click('Search')
+        ->assertSee('No chirps found matching "NonexistentKeyword"');
+});

--- a/tests/Feature/ChirpSearchTest.php
+++ b/tests/Feature/ChirpSearchTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+use function Pest\Laravel\get;
+
+test('displays all chirps when no search keyword is provided', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(3)->for($user)->create();
+
+    $response = get('/');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 3;
+    });
+});
+
+test('displays only matching chirps for partial match search', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Hello world']);
+    Chirp::factory()->for($user)->create(['message' => 'Good morning']);
+    Chirp::factory()->for($user)->create(['message' => 'Hello again']);
+
+    $response = get('/?search=Hello');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 2;
+    });
+    $response->assertSee('Hello world');
+    $response->assertSee('Hello again');
+    $response->assertDontSee('Good morning');
+});
+
+test('search is case insensitive', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Hello World']);
+    Chirp::factory()->for($user)->create(['message' => 'HELLO EVERYONE']);
+    Chirp::factory()->for($user)->create(['message' => 'goodbye']);
+
+    $response = get('/?search=hello');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 2;
+    });
+});
+
+test('displays no results message when no chirps match search', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Hello world']);
+
+    $response = get('/?search=nonexistent');
+
+    $response->assertSuccessful();
+    $response->assertSee('No chirps found matching');
+    $response->assertSee('nonexistent');
+});
+
+test('displays all chirps when search keyword is empty', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(3)->for($user)->create();
+
+    $response = get('/?search=');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 3;
+    });
+});
+
+test('limits results to 50 chirps', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(60)->for($user)->create(['message' => 'Test chirp']);
+
+    $response = get('/');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 50;
+    });
+});
+
+test('search with 50 chirp limit', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(60)->for($user)->create(['message' => 'Searchable chirp']);
+    Chirp::factory()->count(10)->for($user)->create(['message' => 'Different chirp']);
+
+    $response = get('/?search=Searchable');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 50;
+    });
+});
+
+test('handles special characters safely', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Test with @mention']);
+    Chirp::factory()->for($user)->create(['message' => 'Test with #hashtag']);
+    Chirp::factory()->for($user)->create(['message' => 'Test with 100% success']);
+
+    $response = get('/?search=@mention');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 1;
+    });
+});
+
+test('search keyword is preserved in view', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Hello world']);
+
+    $response = get('/?search=Hello');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('search', 'Hello');
+    $response->assertSee('value="Hello"', false);
+});
+
+test('displays no chirps message when no chirps exist and no search', function () {
+    $response = get('/');
+
+    $response->assertSuccessful();
+    $response->assertSee('No chirps yet. Be the first to chirp!');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,8 +12,8 @@
 */
 
 pest()->extend(Tests\TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->in('Feature');
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->in('Feature', 'Browser');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements keyword search functionality for chirps with partial matching on the home page.

Closes #2

## Changes

- **Model**: Add `scopeSearch()` method to Chirp model for LIKE queries
- **Controller**: Update `ChirpController::index()` to handle search parameter
- **View**: Add search form UI with clear button above chirp posting form
- **Factory**: Create ChirpFactory for testing support
- **Tests**: 
  - 10 feature test cases covering all search scenarios
  - 5 browser test cases for UI interactions (requires Pest Browser Plugin)
- **Config**: Enable RefreshDatabase in Pest configuration

## Features

- ✅ Search chirps by message content (partial match)
- ✅ Case-insensitive search
- ✅ Search input preserves value after search
- ✅ "Clear" button appears when search is active
- ✅ Appropriate empty state messages
- ✅ Maintains 50 chirp limit
- ✅ SQL injection safe (Eloquent parameterized queries)
- ✅ XSS safe (Blade auto-escaping)

## Testing

All tests pass:
```
php artisan test --compact
Tests: 12 passed (27 assertions)
```

### Feature Tests (10/10 passed)
- ✅ Displays all chirps when no search keyword
- ✅ Partial match search
- ✅ Case insensitive search
- ✅ No results message
- ✅ Empty search handling
- ✅ 50 chirp limit
- ✅ Search with 50 chirp limit
- ✅ Special characters handling
- ✅ Search keyword preservation
- ✅ No chirps message

### Browser Tests (requires setup)
To run browser tests, install:
```bash
composer require pestphp/pest-plugin-browser:^4.0 --dev
npm install playwright@latest
npx playwright install
```

## Screenshots

The search form is placed above the chirp posting form with:
- Search input field
- Search button with icon
- Conditional "Clear" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)