### PR TITLE
Add user profile feature (Issue #1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,8 +19,11 @@
       "mcp__serena__replace_symbol_body",
       "mcp__serena__check_onboarding_performed",
       "mcp__serena__list_memories",
+      "mcp__serena__initial_instructions",
+      "mcp__serena__find_file",
       "mcp__context7__resolve-library-id",
-      "mcp__context7__query-docs"
+      "mcp__context7__query-docs",
+      "Bash(composer test:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\UpdateProfileRequest;
 use App\Models\User;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Http\Request;
 
 class ProfileController extends Controller
 {
@@ -30,25 +30,9 @@ class ProfileController extends Controller
         return view('profile.edit', compact('user'));
     }
 
-    public function update(Request $request, User $user)
+    public function update(UpdateProfileRequest $request, User $user)
     {
-        $this->authorize('update', $user);
-
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'bio' => 'nullable|string|max:1000',
-            'location' => 'nullable|string|max:255',
-            'website' => 'nullable|url|max:255',
-        ], [
-            'name.required' => 'Please enter your name.',
-            'name.max' => 'Name must be 255 characters or less.',
-            'bio.max' => 'Bio must be 1000 characters or less.',
-            'location.max' => 'Location must be 255 characters or less.',
-            'website.url' => 'Please enter a valid URL.',
-            'website.max' => 'Website must be 255 characters or less.',
-        ]);
-
-        $user->update($validated);
+        $user->update($request->validated());
 
         return redirect()->route('profile.show', $user)->with('success', 'Profile updated successfully!');
     }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function show(User $user)
+    {
+        $chirps = $user->chirps()
+            ->with('user')
+            ->latest()
+            ->paginate(15);
+
+        return view('profile.show', [
+            'user' => $user,
+            'chirps' => $chirps,
+        ]);
+    }
+
+    public function edit(User $user)
+    {
+        $this->authorize('update', $user);
+
+        return view('profile.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $this->authorize('update', $user);
+
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'bio' => 'nullable|string|max:1000',
+            'location' => 'nullable|string|max:255',
+            'website' => 'nullable|url|max:255',
+        ], [
+            'name.required' => 'Please enter your name.',
+            'name.max' => 'Name must be 255 characters or less.',
+            'bio.max' => 'Bio must be 1000 characters or less.',
+            'location.max' => 'Location must be 255 characters or less.',
+            'website.url' => 'Please enter a valid URL.',
+            'website.max' => 'Website must be 255 characters or less.',
+        ]);
+
+        $user->update($validated);
+
+        return redirect()->route('profile.show', $user)->with('success', 'Profile updated successfully!');
+    }
+}

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProfileRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->can('update', $this->route('user'));
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'bio' => 'nullable|string|max:1000',
+            'location' => 'nullable|string|max:255',
+            'website' => 'nullable|url|max:255',
+        ];
+    }
+
+    /**
+     * Get custom error messages for validation rules.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'Please enter your name.',
+            'name.max' => 'Name must be 255 characters or less.',
+            'bio.max' => 'Bio must be 1000 characters or less.',
+            'location.max' => 'Location must be 255 characters or less.',
+            'website.url' => 'Please enter a valid URL.',
+            'website.max' => 'Website must be 255 characters or less.',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,9 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'bio',
+        'location',
+        'website',
     ];
 
     /**

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class UserPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, User $model): bool
+    {
+        return $user->is($model);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, User $model): bool
+    {
+        return false;
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,9 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'bio' => fake()->optional(0.7)->text(200),
+            'location' => fake()->optional(0.6)->city(),
+            'website' => fake()->optional(0.5)->url(),
         ];
     }
 

--- a/database/migrations/2026_02_08_091008_add_profile_fields_to_users_table.php
+++ b/database/migrations/2026_02_08_091008_add_profile_fields_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('bio')->nullable()->after('email');
+            $table->string('location')->nullable()->after('bio');
+            $table->string('website')->nullable()->after('location');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['bio', 'location', 'website']);
+        });
+    }
+};

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,0 +1,117 @@
+# Entity Relationship Diagram
+
+## Database Schema Overview
+
+```mermaid
+erDiagram
+    users ||--o{ chirps : "creates"
+    users ||--o{ sessions : "has"
+    users ||--o{ password_reset_tokens : "requests"
+
+    users {
+        integer id PK
+        varchar name
+        varchar email UK "UNIQUE"
+        datetime email_verified_at
+        varchar password
+        varchar remember_token
+        datetime created_at
+        datetime updated_at
+    }
+
+    chirps {
+        integer id PK
+        integer user_id FK "CASCADE DELETE"
+        varchar message
+        datetime created_at
+        datetime updated_at
+    }
+
+    sessions {
+        varchar id PK
+        integer user_id "INDEXED"
+        varchar ip_address
+        text user_agent
+        text payload
+        integer last_activity "INDEXED"
+    }
+
+    password_reset_tokens {
+        varchar email PK
+        varchar token
+        datetime created_at
+    }
+
+    failed_jobs {
+        integer id PK
+        varchar uuid UK "UNIQUE"
+        text connection
+        text queue
+        text payload
+        text exception
+        datetime failed_at
+    }
+
+    jobs {
+        integer id PK
+        varchar queue "INDEXED"
+        text payload
+        integer attempts
+        integer reserved_at
+        integer available_at
+        integer created_at
+    }
+
+    job_batches {
+        varchar id PK
+        varchar name
+        integer total_jobs
+        integer pending_jobs
+        integer failed_jobs
+        text failed_job_ids
+        text options
+        integer cancelled_at
+        integer created_at
+        integer finished_at
+    }
+
+    cache {
+        varchar key PK
+        text value
+        integer expiration
+    }
+
+    cache_locks {
+        varchar key PK
+        varchar owner
+        integer expiration
+    }
+```
+
+## Core Business Tables
+
+The main business logic revolves around:
+
+- **users**: User accounts and authentication
+- **chirps**: User-generated messages with foreign key relationship to users
+- **sessions**: Active user sessions for authentication state
+- **password_reset_tokens**: Temporary tokens for password reset flow
+
+## Supporting Infrastructure Tables
+
+- **jobs** / **failed_jobs** / **job_batches**: Queue system for background processing
+- **cache** / **cache_locks**: Application caching layer
+
+## Key Relationships
+
+1. **users → chirps**: One-to-many relationship with cascade delete
+2. **users → sessions**: One-to-many relationship (indexed for performance)
+3. **users → password_reset_tokens**: One-to-one relationship via email
+
+## Indexes
+
+- `users.email`: Unique index for authentication
+- `sessions.user_id`: Index for session lookups
+- `sessions.last_activity`: Index for cleanup operations
+- `jobs.queue`: Index for queue processing
+- `failed_jobs.uuid`: Unique index for job identification

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -12,6 +12,7 @@ While in progress, ALWAYS update `docs/progress/issue-XX.md` as the phases and s
 3. **Confirm the plan** - Confirm with the client if the plan can be proceeed. If not, go back to step #3.
 4. **Update the GitHub Issue** - Exit plan mode, and document the plan in the Issue.
 5. **Create a Git Branch** - Create a feature branch for the issue
+  * If not specified, ALL feature branches should be derived from the LATEST main branch.
 6. **Implement** - Write code and tests
 7. **Testing** - Ensure all unit tests pass. When implementing some feature, make sure UI tests are performed with Playwright MCP, too.
 

--- a/resources/views/components/chirp.blade.php
+++ b/resources/views/components/chirp.blade.php
@@ -23,7 +23,13 @@
             <div class="min-w-0 flex-1">
                 <div class="flex justify-between w-full">
                     <div class="flex items-center gap-1">
-                        <span class="text-sm font-semibold">{{ $chirp->user ? $chirp->user->name : 'Anonymous' }}</span>
+                        @if ($chirp->user)
+                            <a href="{{ route('profile.show', $chirp->user) }}" class="text-sm font-semibold link link-hover">
+                                {{ $chirp->user->name }}
+                            </a>
+                        @else
+                            <span class="text-sm font-semibold">Anonymous</span>
+                        @endif
                         <span class="text-base-content/60">·</span>
                         <span class="text-sm text-base-content/60">{{ $chirp->created_at->diffForHumans() }}</span>
                         @if ($chirp->updated_at->gt($chirp->created_at->addSeconds(5)))

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -17,7 +17,9 @@
         </div>
         <div class="navbar-end gap-2">
             @auth
-                <span class="text-sm">{{ auth()->user()->name }}</span>
+                <a href="{{ route('profile.show', auth()->user()) }}" class="text-sm link link-hover">
+                    {{ auth()->user()->name }}
+                </a>
                 <form method="POST" action="/logout" class="inline">
                     @csrf
                     <button type="submit" class="btn btn-ghost btn-sm">Logout</button>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,0 +1,107 @@
+<x-layout>
+    <x-slot:title>
+        Edit Profile
+    </x-slot:title>
+
+    <div class="max-w-2xl mx-auto">
+        <h1 class="text-3xl font-bold mt-8">Edit Profile</h1>
+
+        <div class="card bg-base-100 shadow mt-8">
+            <div class="card-body">
+                <form method="POST" action="{{ route('profile.update', $user) }}">
+                    @csrf
+                    @method('PUT')
+
+                    <!-- Name -->
+                    <div class="form-control w-full">
+                        <label class="label">
+                            <span class="label-text">Name</span>
+                        </label>
+                        <input
+                            type="text"
+                            name="name"
+                            value="{{ old('name', $user->name) }}"
+                            class="input input-bordered w-full @error('name') input-error @enderror"
+                            maxlength="255"
+                            required
+                        >
+                        @error('name')
+                            <div class="label">
+                                <span class="label-text-alt text-error">{{ $message }}</span>
+                            </div>
+                        @enderror
+                    </div>
+
+                    <!-- Bio -->
+                    <div class="form-control w-full mt-4">
+                        <label class="label">
+                            <span class="label-text">Bio</span>
+                        </label>
+                        <textarea
+                            name="bio"
+                            class="textarea textarea-bordered w-full resize-none @error('bio') textarea-error @enderror"
+                            rows="4"
+                            maxlength="1000"
+                            placeholder="Tell us about yourself..."
+                        >{{ old('bio', $user->bio) }}</textarea>
+                        @error('bio')
+                            <div class="label">
+                                <span class="label-text-alt text-error">{{ $message }}</span>
+                            </div>
+                        @enderror
+                    </div>
+
+                    <!-- Location -->
+                    <div class="form-control w-full mt-4">
+                        <label class="label">
+                            <span class="label-text">Location</span>
+                        </label>
+                        <input
+                            type="text"
+                            name="location"
+                            value="{{ old('location', $user->location) }}"
+                            class="input input-bordered w-full @error('location') input-error @enderror"
+                            maxlength="255"
+                            placeholder="Tokyo, Japan"
+                        >
+                        @error('location')
+                            <div class="label">
+                                <span class="label-text-alt text-error">{{ $message }}</span>
+                            </div>
+                        @enderror
+                    </div>
+
+                    <!-- Website -->
+                    <div class="form-control w-full mt-4">
+                        <label class="label">
+                            <span class="label-text">Website</span>
+                        </label>
+                        <input
+                            type="url"
+                            name="website"
+                            value="{{ old('website', $user->website) }}"
+                            class="input input-bordered w-full @error('website') input-error @enderror"
+                            maxlength="255"
+                            placeholder="https://example.com"
+                        >
+                        @error('website')
+                            <div class="label">
+                                <span class="label-text-alt text-error">{{ $message }}</span>
+                            </div>
+                        @enderror
+                    </div>
+
+                    <!-- Actions -->
+                    <div class="card-actions justify-between mt-6">
+                        <a href="{{ route('profile.show', $user) }}" class="btn btn-ghost btn-sm">
+                            Cancel
+                        </a>
+                        <button type="submit" class="btn btn-primary btn-sm">
+                            Update Profile
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-layout>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,0 +1,100 @@
+<x-layout>
+    <x-slot:title>
+        {{ $user->name }}'s Profile
+    </x-slot:title>
+
+    <div class="max-w-2xl mx-auto">
+        <!-- Profile Header -->
+        <div class="card bg-base-100 shadow mt-8">
+            <div class="card-body">
+                <div class="flex items-start gap-4">
+                    <div class="avatar">
+                        <div class="size-24 rounded-full">
+                            <img src="https://avatars.laravel.cloud/{{ urlencode($user->email) }}"
+                                alt="{{ $user->name }}'s avatar" />
+                        </div>
+                    </div>
+
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between">
+                            <h1 class="text-2xl font-bold">{{ $user->name }}</h1>
+                            @can('update', $user)
+                                <a href="{{ route('profile.edit', $user) }}" class="btn btn-primary btn-sm">
+                                    Edit Profile
+                                </a>
+                            @endcan
+                        </div>
+
+                        @if($user->bio)
+                            <p class="mt-3 text-base-content/80 break-words">{{ $user->bio }}</p>
+                        @endif
+
+                        <div class="flex flex-wrap gap-4 mt-4 text-sm text-base-content/60">
+                            @if($user->location)
+                                <div class="flex items-center gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    </svg>
+                                    <span>{{ $user->location }}</span>
+                                </div>
+                            @endif
+
+                            @if($user->website)
+                                <div class="flex items-center gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                                    </svg>
+                                    <a href="{{ $user->website }}" target="_blank" rel="noopener noreferrer" class="link link-hover">
+                                        {{ parse_url($user->website, PHP_URL_HOST) }}
+                                    </a>
+                                </div>
+                            @endif
+
+                            <div class="flex items-center gap-1">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                </svg>
+                                <span>Joined {{ $user->created_at->format('M Y') }}</span>
+                            </div>
+                        </div>
+
+                        <div class="stats shadow mt-4">
+                            <div class="stat py-3 px-4">
+                                <div class="stat-title text-xs">Chirps</div>
+                                <div class="stat-value text-2xl">{{ $user->chirps()->count() }}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Chirps Section -->
+        <h2 class="text-2xl font-bold mt-8">Chirps</h2>
+
+        <div class="space-y-4 mt-6">
+            @forelse ($chirps as $chirp)
+                <x-chirp :chirp="$chirp" />
+            @empty
+                <div class="hero py-12">
+                    <div class="hero-content text-center">
+                        <div>
+                            <svg class="mx-auto h-12 w-12 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
+                            </svg>
+                            <p class="mt-4 text-base-content/60">No chirps yet.</p>
+                        </div>
+                    </div>
+                </div>
+            @endforelse
+        </div>
+
+        <!-- Pagination -->
+        @if ($chirps->hasPages())
+            <div class="mt-8">
+                {{ $chirps->links() }}
+            </div>
+        @endif
+    </div>
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,13 +3,25 @@
 use App\Http\Controllers\Auth\Login;
 use App\Http\Controllers\Auth\Logout;
 use App\Http\Controllers\Auth\Register;
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ChirpController;
+use App\Http\Controllers\ProfileController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', [ChirpController::class, 'index']);
 Route::middleware('auth')->group(function () {
     Route::resource('chirps', ChirpController::class)
         ->only(['store', 'edit', 'update', 'destroy']);
+});
+
+// Profile routes
+Route::get('/users/{user}', [ProfileController::class, 'show'])
+    ->name('profile.show');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/users/{user}/edit', [ProfileController::class, 'edit'])
+        ->name('profile.edit');
+    Route::put('/users/{user}', [ProfileController::class, 'update'])
+        ->name('profile.update');
 });
 
 Route::view('/register', 'auth.register')
@@ -18,7 +30,7 @@ Route::view('/register', 'auth.register')
 Route::post('/register', Register::class)
     ->middleware('guest');
 
-    // Login routes
+// Login routes
 Route::view('/login', 'auth.login')
     ->middleware('guest')
     ->name('login');

--- a/tests/Browser/ProfileBrowserTest.php
+++ b/tests/Browser/ProfileBrowserTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+test('can view user profile page', function () {
+    $user = User::factory()->create([
+        'name' => 'John Doe',
+        'bio' => 'Test bio content',
+        'location' => 'Tokyo',
+        'website' => 'https://example.com',
+    ]);
+    Chirp::factory()->for($user)->create(['message' => 'Test chirp']);
+
+    $page = visit(route('profile.show', $user));
+
+    $page->assertSee('John Doe')
+        ->assertSee('Test bio content')
+        ->assertSee('Tokyo')
+        ->assertSee('example.com')
+        ->assertSee('Test chirp')
+        ->assertNoJavascriptErrors();
+});
+
+test('can navigate to profile from chirp username', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe']);
+    Chirp::factory()->for($user)->create(['message' => 'Test chirp']);
+
+    $page = visit('/');
+
+    $page->assertSee('Jane Doe')
+        ->click('Jane Doe')
+        ->assertSee("Jane Doe's Profile")
+        ->assertNoJavascriptErrors();
+});
+
+test('can edit own profile', function () {
+    $user = User::factory()->create([
+        'name' => 'Original Name',
+        'bio' => 'Original bio',
+    ]);
+
+    $page = loginAs($user)
+        ->visit(route('profile.show', $user));
+
+    $page->assertSee('Edit Profile')
+        ->click('Edit Profile')
+        ->assertSee('Edit Profile')
+        ->fill('name', 'Updated Name')
+        ->fill('bio', 'Updated bio content')
+        ->fill('location', 'Osaka')
+        ->fill('website', 'https://updated.com')
+        ->click('Update Profile')
+        ->assertSee('Profile updated successfully!')
+        ->assertSee('Updated Name')
+        ->assertSee('Updated bio content')
+        ->assertSee('Osaka')
+        ->assertSee('updated.com')
+        ->assertNoJavascriptErrors();
+});
+
+test('edit profile cancel button returns to profile', function () {
+    $user = User::factory()->create(['name' => 'John Doe']);
+
+    $page = loginAs($user)
+        ->visit(route('profile.edit', $user));
+
+    $page->assertSee('Edit Profile')
+        ->click('Cancel')
+        ->assertSee("John Doe's Profile")
+        ->assertNoJavascriptErrors();
+});
+
+test('shows validation errors for invalid profile data', function () {
+    $user = User::factory()->create();
+
+    $page = loginAs($user)
+        ->visit(route('profile.edit', $user));
+
+    $page->fill('name', '')
+        ->fill('website', 'not-a-valid-url')
+        ->click('Update Profile')
+        ->assertSee('Please enter your name')
+        ->assertSee('Please enter a valid URL')
+        ->assertNoJavascriptErrors();
+});
+
+test('profile page shows empty state when user has no chirps', function () {
+    $user = User::factory()->create(['name' => 'Empty User']);
+
+    $page = visit(route('profile.show', $user));
+
+    $page->assertSee('Empty User')
+        ->assertSee('No chirps yet')
+        ->assertNoJavascriptErrors();
+});
+
+test('edit profile button is not visible for other users', function () {
+    $user = User::factory()->create(['name' => 'John Doe']);
+    $otherUser = User::factory()->create();
+
+    $page = loginAs($otherUser)
+        ->visit(route('profile.show', $user));
+
+    $page->assertSee('John Doe')
+        ->assertDontSee('Edit Profile')
+        ->assertNoJavascriptErrors();
+});
+
+test('profile page is accessible without authentication', function () {
+    $user = User::factory()->create(['name' => 'Public User']);
+
+    $page = visit(route('profile.show', $user));
+
+    $page->assertSee('Public User')
+        ->assertDontSee('Edit Profile')
+        ->assertNoJavascriptErrors();
+});

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,0 +1,239 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\put;
+
+// Profile Display Tests
+test('displays user profile page for any user', function () {
+    $user = User::factory()->create([
+        'name' => 'John Doe',
+        'bio' => 'Test bio',
+        'location' => 'Tokyo',
+        'website' => 'https://example.com',
+    ]);
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertSee('John Doe');
+    $response->assertSee('Test bio');
+    $response->assertSee('Tokyo');
+    $response->assertSee('example.com');
+});
+
+test('displays user profile page without authentication', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe']);
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertSee('Jane Doe');
+});
+
+test('displays user chirps on profile page', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(3)->for($user)->create();
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 3;
+    });
+});
+
+test('paginates user chirps to 15 per page', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->count(20)->for($user)->create();
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 15;
+    });
+});
+
+test('displays empty state when user has no chirps', function () {
+    $user = User::factory()->create();
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertSee('No chirps yet');
+});
+
+test('displays profile with nullable fields empty', function () {
+    $user = User::factory()->create([
+        'name' => 'John Doe',
+        'bio' => null,
+        'location' => null,
+        'website' => null,
+    ]);
+
+    $response = get(route('profile.show', $user));
+
+    $response->assertSuccessful();
+    $response->assertSee('John Doe');
+});
+
+// Profile Edit Tests
+test('displays edit profile page for authenticated user', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->get(route('profile.edit', $user));
+
+    $response->assertSuccessful();
+    $response->assertSee('Edit Profile');
+});
+
+test('redirects to login when unauthenticated user tries to edit profile', function () {
+    $user = User::factory()->create();
+
+    $response = get(route('profile.edit', $user));
+
+    $response->assertRedirect(route('login'));
+});
+
+test('denies access when user tries to edit another user profile', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $response = actingAs($user)->get(route('profile.edit', $otherUser));
+
+    $response->assertForbidden();
+});
+
+// Profile Update Tests
+test('updates user profile successfully', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Updated Name',
+        'bio' => 'Updated bio',
+        'location' => 'Updated location',
+        'website' => 'https://updated.com',
+    ]);
+
+    $response->assertRedirect(route('profile.show', $user));
+    $response->assertSessionHas('success', 'Profile updated successfully!');
+
+    $user->refresh();
+    expect($user->name)->toBe('Updated Name');
+    expect($user->bio)->toBe('Updated bio');
+    expect($user->location)->toBe('Updated location');
+    expect($user->website)->toBe('https://updated.com');
+});
+
+test('denies profile update for unauthenticated user', function () {
+    $user = User::factory()->create();
+
+    $response = put(route('profile.update', $user), [
+        'name' => 'Updated Name',
+    ]);
+
+    $response->assertRedirect(route('login'));
+});
+
+test('denies profile update when user tries to update another user', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $otherUser), [
+        'name' => 'Updated Name',
+    ]);
+
+    $response->assertForbidden();
+});
+
+// Validation Tests
+test('requires name field', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => '',
+    ]);
+
+    $response->assertSessionHasErrors('name');
+});
+
+test('validates name max length', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => str_repeat('a', 256),
+    ]);
+
+    $response->assertSessionHasErrors('name');
+});
+
+test('validates bio max length', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Valid Name',
+        'bio' => str_repeat('a', 1001),
+    ]);
+
+    $response->assertSessionHasErrors('bio');
+});
+
+test('validates location max length', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Valid Name',
+        'location' => str_repeat('a', 256),
+    ]);
+
+    $response->assertSessionHasErrors('location');
+});
+
+test('validates website url format', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Valid Name',
+        'website' => 'not-a-valid-url',
+    ]);
+
+    $response->assertSessionHasErrors('website');
+});
+
+test('validates website max length', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Valid Name',
+        'website' => 'https://'.str_repeat('a', 256).'.com',
+    ]);
+
+    $response->assertSessionHasErrors('website');
+});
+
+test('allows nullable fields to be empty', function () {
+    $user = User::factory()->create([
+        'bio' => 'Old bio',
+        'location' => 'Old location',
+        'website' => 'https://old.com',
+    ]);
+
+    $response = actingAs($user)->put(route('profile.update', $user), [
+        'name' => 'Updated Name',
+        'bio' => null,
+        'location' => null,
+        'website' => null,
+    ]);
+
+    $response->assertRedirect(route('profile.show', $user));
+
+    $user->refresh();
+    expect($user->name)->toBe('Updated Name');
+    expect($user->bio)->toBeNull();
+    expect($user->location)->toBeNull();
+    expect($user->website)->toBeNull();
+});


### PR DESCRIPTION
## Summary
ユーザープロフィール機能を実装しました。ユーザーは自分のプロフィール情報を管理・公開でき、他のユーザーのプロフィールや投稿履歴を閲覧できます。

## Changes
- **Database**: `users` テーブルに `bio`, `location`, `website` カラムを追加
- **Models**: `User` モデルと `UserFactory` を更新
- **Controllers**: `ProfileController` を作成（show, edit, update アクション）
- **Policies**: `UserPolicy` を作成（自分のプロフィールのみ編集可能）
- **Views**: プロフィール表示・編集ページを作成
- **Navigation**: Chirp とヘッダーのユーザー名をプロフィールページへリンク
- **Tests**: Feature テスト 19 件、Browser テスト 8 件を追加

## Features
- ✅ プロフィール表示（全ユーザー閲覧可能）
- ✅ プロフィール編集（認証済みユーザーが自分のプロフィールを編集）
- ✅ プロフィールフィールド（bio, location, website）
- ✅ ユーザーの Chirp 一覧（15 件ごとのページネーション）
- ✅ ユーザー名からプロフィールへのナビゲーション

## Test Results
```
Tests:    35 passed (83 assertions)
Duration: 0.59s
```

## Screenshots
プロフィール表示ページとプロフィール編集ページを実装。DaisyUI コンポーネントを使用した一貫性のある UI デザイン。

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)