### PR TITLE
Fix broken browser tests for Pest Browser Plugin v4

### DIFF
--- a/tests/Browser/ChirpSearchBrowserTest.php
+++ b/tests/Browser/ChirpSearchBrowserTest.php
@@ -42,7 +42,7 @@ test('search input preserves value after search', function () {
 
     $page->fill('search', 'Searchable')
         ->click('Search')
-        ->assertInputValue('search', 'Searchable');
+        ->assertValue('input[name="search"]', 'Searchable');
 });
 
 test('clear button redirects to home and clears search', function () {
@@ -53,7 +53,7 @@ test('clear button redirects to home and clears search', function () {
 
     $page->assertSee('Clear')
         ->click('Clear')
-        ->assertInputValue('search', '');
+        ->assertValue('input[name="search"]', '');
 });
 
 test('displays no results message when search returns nothing', function () {

--- a/tests/Browser/ProfileBrowserTest.php
+++ b/tests/Browser/ProfileBrowserTest.php
@@ -30,7 +30,7 @@ test('can navigate to profile from chirp username', function () {
 
     $page->assertSee('Jane Doe')
         ->click('Jane Doe')
-        ->assertSee("Jane Doe's Profile")
+        ->assertTitleContains("Jane Doe's Profile")
         ->assertNoJavascriptErrors();
 });
 
@@ -40,8 +40,8 @@ test('can edit own profile', function () {
         'bio' => 'Original bio',
     ]);
 
-    $page = loginAs($user)
-        ->visit(route('profile.show', $user));
+    $page = browserLogin($user)
+        ->navigate(route('profile.show', $user));
 
     $page->assertSee('Edit Profile')
         ->click('Edit Profile')
@@ -62,25 +62,27 @@ test('can edit own profile', function () {
 test('edit profile cancel button returns to profile', function () {
     $user = User::factory()->create(['name' => 'John Doe']);
 
-    $page = loginAs($user)
-        ->visit(route('profile.edit', $user));
+    $page = browserLogin($user)
+        ->navigate(route('profile.edit', $user));
 
     $page->assertSee('Edit Profile')
         ->click('Cancel')
-        ->assertSee("John Doe's Profile")
+        ->assertTitleContains("John Doe's Profile")
         ->assertNoJavascriptErrors();
 });
 
 test('shows validation errors for invalid profile data', function () {
     $user = User::factory()->create();
 
-    $page = loginAs($user)
-        ->visit(route('profile.edit', $user));
+    $page = browserLogin($user)
+        ->navigate(route('profile.edit', $user));
 
     $page->fill('name', '')
-        ->fill('website', 'not-a-valid-url')
-        ->click('Update Profile')
-        ->assertSee('Please enter your name')
+        ->fill('website', 'not-a-valid-url');
+
+    $page->script("document.querySelector('.card-body form').submit()");
+
+    $page->assertSee('Please enter your name')
         ->assertSee('Please enter a valid URL')
         ->assertNoJavascriptErrors();
 });
@@ -99,8 +101,8 @@ test('edit profile button is not visible for other users', function () {
     $user = User::factory()->create(['name' => 'John Doe']);
     $otherUser = User::factory()->create();
 
-    $page = loginAs($otherUser)
-        ->visit(route('profile.show', $user));
+    $page = browserLogin($otherUser)
+        ->navigate(route('profile.show', $user));
 
     $page->assertSee('John Doe')
         ->assertDontSee('Edit Profile')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -41,7 +41,10 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function browserLogin(App\Models\User $user): \Pest\Browser\Api\AwaitableWebpage
 {
-    // ..
+    return visit('/login')
+        ->fill('email', $user->email)
+        ->fill('password', 'password')
+        ->submit('form');
 }


### PR DESCRIPTION
## Summary
- Replace Dusk-specific `loginAs()` with `browserLogin()` helper using Pest Browser Plugin v4 API
- Replace `assertInputValue()` with `assertValue()` (CSS selector based)
- Fix `assertSee()` for title-only text by using `assertTitleContains()`
- Bypass HTML5 form validation in server-side validation test via `script("form.submit()")`

Closes #19

## Test plan
- [x] All 17 browser tests pass
- [x] All 45 Feature/Unit tests pass
- [x] Code formatted with Pint

🤖 Generated with [Claude Code](https://claude.com/claude-code)