### PR TITLE
Implement follow system with tab-based feed filtering

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,6 +6,7 @@
       "Bash(composer show:*)",
       "Bash(vendor/bin/pint:*)",
       "Bash(vendor/bin/pest:*)",
+      "Bash(npm run build:*)",
       "WebFetch(domain:daisyui.com)",
       "mcp__laravel-boost__list-routes",
       "mcp__laravel-boost__application-info",

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function store(Request $request, User $user)
+    {
+        $this->authorize('follow', $user);
+
+        auth()->user()->following()->syncWithoutDetaching($user->id);
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'followers_count' => $user->followers()->count(),
+                'is_following' => true,
+            ]);
+        }
+
+        return back();
+    }
+
+    public function destroy(Request $request, User $user)
+    {
+        $this->authorize('follow', $user);
+
+        auth()->user()->following()->detach($user->id);
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'followers_count' => $user->followers()->count(),
+                'is_following' => false,
+            ]);
+        }
+
+        return back();
+    }
+}

--- a/app/Models/Chirp.php
+++ b/app/Models/Chirp.php
@@ -34,4 +34,11 @@ class Chirp extends Model
     {
         return $this->belongsToMany(User::class, 'likes')->withTimestamps();
     }
+
+    public function scopeFromFollowing(Builder $query, User $user): Builder
+    {
+        $followingIds = $user->following()->pluck('users.id');
+
+        return $query->whereIn('user_id', $followingIds->push($user->id));
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,4 +60,14 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(Chirp::class, 'likes')->withTimestamps();
     }
+
+    public function following(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'follows', 'follower_id', 'following_id')->withTimestamps();
+    }
+
+    public function followers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'follows', 'following_id', 'follower_id')->withTimestamps();
+    }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -55,6 +55,14 @@ class UserPolicy
     }
 
     /**
+     * Determine whether the user can follow the model.
+     */
+    public function follow(User $user, User $model): bool
+    {
+        return ! $user->is($model);
+    }
+
+    /**
      * Determine whether the user can permanently delete the model.
      */
     public function forceDelete(User $user, User $model): bool

--- a/database/migrations/2026_02_11_053653_create_follows_table.php
+++ b/database/migrations/2026_02_11_053653_create_follows_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('follower_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('following_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['follower_id', 'following_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('follows');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,2 +1,3 @@
 import './bootstrap';
 import './likes';
+import './follows';

--- a/resources/js/follows.js
+++ b/resources/js/follows.js
@@ -1,0 +1,81 @@
+function formatCount(count) {
+    if (count >= 1000) {
+        const k = count / 1000;
+        return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`;
+    }
+    return count.toString();
+}
+
+function updateAllButtonsForUser(userId, isFollowing) {
+    document.querySelectorAll(`.follow-button[data-user-id="${userId}"]`).forEach((btn) => {
+        btn.dataset.following = isFollowing ? 'true' : 'false';
+        const textEl = btn.querySelector('.follow-text');
+
+        if (isFollowing) {
+            btn.classList.remove('btn-outline');
+            btn.classList.add('btn-primary');
+            if (textEl) textEl.textContent = 'Following';
+        } else {
+            btn.classList.add('btn-outline');
+            btn.classList.add('btn-primary');
+            if (textEl) textEl.textContent = 'Follow';
+        }
+    });
+}
+
+function updateFollowerCounts(userId, count) {
+    document.querySelectorAll(`.followers-count[data-user-id="${userId}"]`).forEach((el) => {
+        el.textContent = formatCount(count);
+    });
+}
+
+// Hover effect: "Following" -> "Unfollow"
+document.addEventListener('mouseenter', (e) => {
+    if (!e.target || !e.target.closest) return;
+    const button = e.target.closest('.follow-button');
+    if (!button || button.dataset.following !== 'true') return;
+
+    const textEl = button.querySelector('.follow-text');
+    if (textEl) {
+        textEl.textContent = 'Unfollow';
+        button.classList.remove('btn-primary');
+        button.classList.add('btn-error');
+    }
+}, true);
+
+document.addEventListener('mouseleave', (e) => {
+    if (!e.target || !e.target.closest) return;
+    const button = e.target.closest('.follow-button');
+    if (!button || button.dataset.following !== 'true') return;
+
+    const textEl = button.querySelector('.follow-text');
+    if (textEl) {
+        textEl.textContent = 'Following';
+        button.classList.remove('btn-error');
+        button.classList.add('btn-primary');
+    }
+}, true);
+
+document.addEventListener('click', async (e) => {
+    const button = e.target.closest('.follow-button');
+    if (!button || button.disabled) return;
+
+    const userId = button.dataset.userId;
+    const isFollowing = button.dataset.following === 'true';
+    const method = isFollowing ? 'DELETE' : 'POST';
+    const url = `/users/${userId}/follow`;
+
+    button.disabled = true;
+
+    try {
+        const response = await axios({ method, url });
+        const { followers_count, is_following } = response.data;
+
+        updateAllButtonsForUser(userId, is_following);
+        updateFollowerCounts(userId, followers_count);
+    } catch (error) {
+        console.error('Follow action failed:', error);
+    } finally {
+        button.disabled = false;
+    }
+});

--- a/resources/views/components/chirp.blade.php
+++ b/resources/views/components/chirp.blade.php
@@ -30,6 +30,26 @@
                         @else
                             <span class="text-sm font-semibold">Anonymous</span>
                         @endif
+
+                        {{-- Follow Button --}}
+                        @auth
+                            @if ($chirp->user && $chirp->user->id !== auth()->id())
+                                @php
+                                    $isFollowing = $chirp->user->relationLoaded('followers')
+                                        ? $chirp->user->followers->contains(auth()->user())
+                                        : false;
+                                @endphp
+                                <button
+                                    type="button"
+                                    class="follow-button btn btn-xs {{ $isFollowing ? 'btn-primary' : 'btn-outline btn-primary' }}"
+                                    data-user-id="{{ $chirp->user->id }}"
+                                    data-following="{{ $isFollowing ? 'true' : 'false' }}"
+                                >
+                                    <span class="follow-text">{{ $isFollowing ? 'Following' : 'Follow' }}</span>
+                                </button>
+                            @endif
+                        @endauth
+
                         <span class="text-base-content/60">·</span>
                         <span class="text-sm text-base-content/60">{{ $chirp->created_at->diffForHumans() }}</span>
                         @if ($chirp->updated_at->gt($chirp->created_at->addSeconds(5)))
@@ -56,6 +76,16 @@
                         </div>
                     @endcan
                 </div>
+
+                {{-- Social Counters --}}
+                @if ($chirp->user)
+                    <div class="flex items-center gap-2 text-xs text-base-content/50">
+                        <span class="followers-count" data-user-id="{{ $chirp->user->id }}">{{ $chirp->user->followers_count ?? 0 }}</span> followers
+                        <span>·</span>
+                        <span>{{ $chirp->user->following_count ?? 0 }}</span> following
+                    </div>
+                @endif
+
                 <p class="mt-1">{{ $chirp->message }}</p>
 
                 <div class="mt-2 flex items-center gap-1">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -8,6 +8,7 @@
 
         <!-- Search Form -->
         <form method="GET" action="/" class="mt-8">
+            <input type="hidden" name="tab" value="{{ $tab }}">
             <div class="form-control">
                 <div class="join w-full">
                     <input
@@ -25,13 +26,27 @@
                         Search
                     </button>
                     @if($search)
-                        <a href="/" class="btn btn-ghost join-item">
+                        <a href="/?tab={{ $tab }}" class="btn btn-ghost join-item">
                             Clear
                         </a>
                     @endif
                 </div>
             </div>
         </form>
+
+        <!-- Tabs -->
+        @auth
+            <div role="tablist" class="tabs tabs-bordered mt-8">
+                <a role="tab" href="/?search={{ urlencode($search) }}&tab=all"
+                   class="tab {{ $tab === 'all' ? 'tab-active' : '' }}">
+                    All Chirps
+                </a>
+                <a role="tab" href="/?search={{ urlencode($search) }}&tab=following"
+                   class="tab {{ $tab === 'following' ? 'tab-active' : '' }}">
+                    Following
+                </a>
+            </div>
+        @endauth
 
         <!-- Chirp Form -->
         <div class="card bg-base-100 shadow mt-8">
@@ -78,6 +93,8 @@
                             <p class="mt-4 text-base-content/60">
                                 @if($search)
                                     No chirps found matching "{{ $search }}". Try a different search term.
+                                @elseif($tab === 'following')
+                                    Follow some users to see their chirps here!
                                 @else
                                     No chirps yet. Be the first to chirp!
                                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Auth\Login;
 use App\Http\Controllers\Auth\Logout;
 use App\Http\Controllers\Auth\Register;
 use App\Http\Controllers\ChirpController;
+use App\Http\Controllers\FollowController;
 use App\Http\Controllers\LikeController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
@@ -15,6 +16,9 @@ Route::middleware('auth')->group(function () {
 
     Route::post('/chirps/{chirp}/likes', [LikeController::class, 'store'])->name('chirps.likes.store');
     Route::delete('/chirps/{chirp}/likes', [LikeController::class, 'destroy'])->name('chirps.likes.destroy');
+
+    Route::post('/users/{user}/follow', [FollowController::class, 'store'])->name('users.follow.store');
+    Route::delete('/users/{user}/follow', [FollowController::class, 'destroy'])->name('users.follow.destroy');
 });
 
 // Profile routes

--- a/tests/Browser/FollowBrowserTest.php
+++ b/tests/Browser/FollowBrowserTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+test('user can follow and unfollow asynchronously', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Chirp::factory()->for($other)->create(['message' => 'Followable chirp']);
+
+    browserLogin($user)
+        ->navigate('/')
+        ->assertSee('Followable chirp')
+        ->assertPresent('.follow-button')
+        ->click('.follow-button')
+        ->waitForText('Following')
+        ->assertSee('Following')
+        ->click('.follow-button')
+        ->waitForText('Follow')
+        ->assertSee('Follow')
+        ->assertNoJavascriptErrors();
+});
+
+test('follower count updates without page reload', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Chirp::factory()->for($other)->create(['message' => 'Count test chirp']);
+
+    browserLogin($user)
+        ->navigate('/')
+        ->assertSee('Count test chirp')
+        ->assertSee('0 followers')
+        ->click('.follow-button')
+        ->waitForText('Following')
+        ->assertSee('1 followers')
+        ->assertNoJavascriptErrors();
+});
+
+test('own chirps do not show follow button', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'My own chirp here']);
+
+    browserLogin($user)
+        ->navigate('/')
+        ->assertSee('My own chirp here')
+        ->assertNotPresent('.follow-button')
+        ->assertNoJavascriptErrors();
+});
+
+test('multiple chirps from same user update together', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Chirp::factory()->for($other)->create(['message' => 'First chirp by other']);
+    Chirp::factory()->for($other)->create(['message' => 'Second chirp by other']);
+
+    browserLogin($user)
+        ->navigate('/')
+        ->assertSee('First chirp by other')
+        ->assertSee('Second chirp by other')
+        ->click(".follow-button[data-user-id=\"{$other->id}\"] >> nth=0")
+        ->waitForText('Following')
+        ->assertNoJavascriptErrors();
+});
+
+test('tabs switch between all and following', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+    $notFollowed = User::factory()->create();
+
+    Chirp::factory()->for($followed)->create(['message' => 'Followed user chirp']);
+    Chirp::factory()->for($notFollowed)->create(['message' => 'Random user chirp']);
+
+    $user->following()->attach($followed);
+
+    browserLogin($user)
+        ->navigate('/')
+        ->assertSee('Followed user chirp')
+        ->assertSee('Random user chirp')
+        ->click('a[href*="tab=following"]')
+        ->waitForText('Followed user chirp')
+        ->assertSee('Followed user chirp')
+        ->assertDontSee('Random user chirp')
+        ->assertNoJavascriptErrors();
+});
+
+test('following tab shows empty state message', function () {
+    $user = User::factory()->create();
+
+    browserLogin($user)
+        ->navigate('/?tab=following')
+        ->assertSee('Follow some users to see their chirps here!')
+        ->assertNoJavascriptErrors();
+});
+
+test('guest does not see follow buttons', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Public chirp for guest']);
+
+    visit('/')
+        ->assertSee('Public chirp for guest')
+        ->assertNotPresent('.follow-button')
+        ->assertNoJavascriptErrors();
+});

--- a/tests/Feature/FollowTest.php
+++ b/tests/Feature/FollowTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+test('guests cannot follow a user', function () {
+    $user = User::factory()->create();
+
+    $response = post("/users/{$user->id}/follow");
+
+    $response->assertRedirect('/login');
+    expect($user->followers()->count())->toBe(0);
+});
+
+test('authenticated user can follow another user', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $response = actingAs($user)->post("/users/{$other->id}/follow");
+
+    $response->assertRedirect();
+    expect($other->followers()->count())->toBe(1);
+    expect($other->followers()->first()->id)->toBe($user->id);
+});
+
+test('user can unfollow another user', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $user->following()->attach($other);
+
+    $response = actingAs($user)->delete("/users/{$other->id}/follow");
+
+    $response->assertRedirect();
+    expect($other->followers()->count())->toBe(0);
+});
+
+test('user cannot follow themselves', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->post("/users/{$user->id}/follow");
+
+    $response->assertForbidden();
+    expect($user->followers()->count())->toBe(0);
+});
+
+test('following the same user twice is idempotent', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $user->following()->attach($other);
+
+    $response = actingAs($user)->post("/users/{$other->id}/follow");
+
+    $response->assertRedirect();
+    expect($other->followers()->count())->toBe(1);
+});
+
+test('follow via ajax returns json with count and status', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $response = actingAs($user)
+        ->postJson("/users/{$other->id}/follow");
+
+    $response->assertOk()
+        ->assertJson([
+            'followers_count' => 1,
+            'is_following' => true,
+        ]);
+});
+
+test('unfollow via ajax returns json with count and status', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $user->following()->attach($other);
+
+    $response = actingAs($user)
+        ->deleteJson("/users/{$other->id}/follow");
+
+    $response->assertOk()
+        ->assertJson([
+            'followers_count' => 0,
+            'is_following' => false,
+        ]);
+});
+
+test('follower count is available on chirps in home page', function () {
+    $chirpOwner = User::factory()->create();
+    $follower = User::factory()->create();
+    Chirp::factory()->for($chirpOwner)->create();
+    $follower->following()->attach($chirpOwner);
+
+    $response = actingAs($follower)->get('/');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->first()->user->followers_count === 1;
+    });
+});

--- a/tests/Feature/FollowingFeedTest.php
+++ b/tests/Feature/FollowingFeedTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\Chirp;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+test('all tab shows all chirps by default', function () {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    Chirp::factory()->for($other)->create(['message' => 'Hello from other']);
+
+    $response = actingAs($user)->get('/');
+
+    $response->assertSuccessful();
+    $response->assertSee('Hello from other');
+    $response->assertViewHas('tab', 'all');
+});
+
+test('following tab shows only followed users and own chirps', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+    $notFollowed = User::factory()->create();
+
+    Chirp::factory()->for($user)->create(['message' => 'My own chirp']);
+    Chirp::factory()->for($followed)->create(['message' => 'Followed chirp']);
+    Chirp::factory()->for($notFollowed)->create(['message' => 'Not followed chirp']);
+
+    $user->following()->attach($followed);
+
+    $response = actingAs($user)->get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertSee('My own chirp');
+    $response->assertSee('Followed chirp');
+    $response->assertDontSee('Not followed chirp');
+    $response->assertViewHas('tab', 'following');
+});
+
+test('following tab shows own chirps even when not following anyone', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'My solo chirp']);
+
+    $response = actingAs($user)->get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertSee('My solo chirp');
+});
+
+test('following tab shows empty state when no chirps', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertSee('Follow some users to see their chirps here!');
+});
+
+test('following tab with search works', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+    Chirp::factory()->for($followed)->create(['message' => 'Findable chirp']);
+    Chirp::factory()->for($followed)->create(['message' => 'Other chirp']);
+    $user->following()->attach($followed);
+
+    $response = actingAs($user)->get('/?tab=following&search=Findable');
+
+    $response->assertSuccessful();
+    $response->assertSee('Findable chirp');
+    $response->assertDontSee('Other chirp');
+});
+
+test('following tab pagination works', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+    Chirp::factory()->for($followed)->count(20)->create();
+    $user->following()->attach($followed);
+
+    $response = actingAs($user)->get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertViewHas('chirps', function ($chirps) {
+        return $chirps->count() === 15;
+    });
+});
+
+test('pagination links preserve tab parameter', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+    Chirp::factory()->for($followed)->count(20)->create();
+    $user->following()->attach($followed);
+
+    $response = actingAs($user)->get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertSee('tab=following');
+});
+
+test('guest accessing following tab falls back to all', function () {
+    $user = User::factory()->create();
+    Chirp::factory()->for($user)->create(['message' => 'Public chirp']);
+
+    $response = get('/?tab=following');
+
+    $response->assertSuccessful();
+    $response->assertSee('Public chirp');
+    $response->assertViewHas('tab', 'all');
+});


### PR DESCRIPTION
## Summary
- Add follow/unfollow functionality with async UI (follow button on each chirp, hover "Following" → "Unfollow" effect)
- Add "All Chirps" / "Following" tab switching on home feed, with query string preserved across search and pagination
- Display followers/following counters on each chirp card
- Self-follow prevented via UserPolicy authorization

## Changes
### New files
- `database/migrations/..._create_follows_table.php` — follows pivot table
- `app/Http/Controllers/FollowController.php` — store/destroy with JSON support
- `resources/js/follows.js` — async follow/unfollow with bulk button updates
- `tests/Feature/FollowTest.php` — 8 tests (auth, idempotency, JSON responses)
- `tests/Feature/FollowingFeedTest.php` — 8 tests (tab filtering, pagination, guest fallback)
- `tests/Browser/FollowBrowserTest.php` — 7 tests (async UI, counters, tabs, guests)

### Modified files
- `app/Models/User.php` — `following()`, `followers()` relations
- `app/Models/Chirp.php` — `scopeFromFollowing()` query scope
- `app/Policies/UserPolicy.php` — `follow()` authorization
- `app/Http/Controllers/ChirpController.php` — tab support, eager loading with withCount
- `routes/web.php` — POST/DELETE `/users/{user}/follow`
- `resources/views/home.blade.php` — tabs UI, tab-aware search/clear/empty state
- `resources/views/components/chirp.blade.php` — follow button, social counters
- `resources/js/app.js` — import follows.js

## Test plan
- [x] `composer test` — 61 feature tests passing
- [x] Browser tests — 24 browser tests passing (7 new follow tests)
- [x] `vendor/bin/pint --dirty` — code formatted

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)